### PR TITLE
Book routing from about author page list and fixed some scaling issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3782,6 +3782,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -11687,6 +11692,28 @@
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
+    },
+    "react-star-ratings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-star-ratings/-/react-star-ratings-2.3.0.tgz",
+      "integrity": "sha512-34Z/oFNDRRn4ZcX7F3t9ccnpo7SQ32gD/vsusQOBc6B6vlqaGR6tke1/Yx3jTDjemKRSmXqhKgpPTR7/JAXq6A==",
+      "requires": {
+        "classnames": "^2.2.1",
+        "prop-types": "^15.6.0",
+        "react": "^16.1.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "react-star-ratings": "^2.3.0",
     "web-vitals": "^1.1.0"
   },
   "scripts": {

--- a/src/components/AboutAuthor.jsx
+++ b/src/components/AboutAuthor.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { withRouter } from "react-router";
 import axios from "axios";
+import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
 
 function AboutAuthor(props) {
   const [booklist, setBooklist] = useState([]);
@@ -12,8 +13,6 @@ function AboutAuthor(props) {
       .then((response) => setBooklist(response.data))
       .catch((error) => console.log(error));
   }, []);
-
-  console.log(booklist);
 
   return (
     <div class="row">
@@ -38,30 +37,39 @@ function AboutAuthor(props) {
             <div class="container">
               <div class="row">
                 {booklist.map((book) => {
-                  const { title, cover, genre } = book;
+                  console.log(book);
+                  const { title, cover, genre, _id } = book;
                   return (
                     <div class="col-sm-12 col-lg-6">
-                      <div class="card mb-3">
-                        <div class="row no-gutters">
-                          <div class="col-lg-4">
-                            <img
-                              src={cover}
-                              class="author-card-img"
-                              alt="book cover"
-                            />
-                          </div>
-                          <div class="col-lg-8">
-                            <div class="card-body">
-                              <h5 class="card-title">{title}</h5>
-                              <hr />
-                              <h6 class="card-text">
-                                Price: ${book.price?.$numberDecimal}
-                              </h6>
-                              <h6 class="card-text">Genre: {genre}</h6>
+                      <Link
+                        to={{
+                          pathname: "/bookDetails",
+                          id: _id,
+                        }}
+                        style={{ textDecoration: "inherit", color: "inherit" }}
+                      >
+                        <div class="card mb-3">
+                          <div class="row no-gutters">
+                            <div class="col-lg-4">
+                              <img
+                                src={cover}
+                                class="author-card-img"
+                                alt="book cover"
+                              />
+                            </div>
+                            <div class="col-lg-8">
+                              <div class="card-body">
+                                <h5 class="card-title">{title}</h5>
+                                <hr />
+                                <h6 class="card-text">
+                                  Price: ${book.price?.$numberDecimal}
+                                </h6>
+                                <h6 class="card-text">Genre: {genre}</h6>
+                              </div>
                             </div>
                           </div>
                         </div>
-                      </div>
+                      </Link>
                     </div>
                   );
                 })}

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import BookInfo from "./subcomponents/BookInfo";
 import CommentingRating from "./subcomponents/CommentingRating";
 import axios from "axios";
+import { withRouter } from "react-router";
 
 // Placeholder book object
 
@@ -22,10 +23,13 @@ const book = {
 };
 */
 
-function BookDetails() {
-  // This title will be passed in as a param when we have the book browsing done
-  const title = "Harry Potter and the Chamber of Secrets";
-  const url = "http://localhost:5000/books/book?title=" + title;
+function BookDetails(props) {
+  // Testing
+  // const title = "Harry Potter and the Chamber of Secrets";
+  // const url = "http://localhost:5000/books/book?title=" + title;
+
+  // Routing from about author page
+  const url = "http://localhost:5000/books/book/id?_id=" + props.location.id;
 
   const [book, setBook] = useState([]);
 
@@ -44,4 +48,4 @@ function BookDetails() {
   );
 }
 
-export default BookDetails;
+export default withRouter(BookDetails);

--- a/src/components/subcomponents/BookInfo.jsx
+++ b/src/components/subcomponents/BookInfo.jsx
@@ -23,7 +23,9 @@ function BookInfo(props) {
                 <h5 id="bookauthor" class="card-title">
                   By {props.book.author}
                 </h5>
-                <p class="card-text">{props.book.description}</p>
+                <p class="card-text" class="book-desc">
+                  {props.book.description}
+                </p>
                 <p id="bookdetails" class="card-text">
                   <span style={{ paddingRight: "71px", fontWeight: "500" }}>
                     PUBLISHER

--- a/src/styling/App.css
+++ b/src/styling/App.css
@@ -131,8 +131,8 @@ a:visited {
 
 .cart-card-img {
   display: block;
-  max-width:250px;
-  max-height:250px;
+  max-width: 250px;
+  max-height: 250px;
   width: auto;
   height: auto;
   border-radius: 15px 50px;
@@ -211,4 +211,9 @@ a:visited {
 .author-card-img {
   width: auto;
   height: 190px;
+}
+
+.book-desc {
+  height: 70px;
+  overflow: auto;
 }


### PR DESCRIPTION
Did book routing from the about author page. Essentially if you're in the about author page, you can now click on one of the books in the list and get to the book details page for that book.

Initially if you want to get to the bookdetails page, you must uncomment lines 28 and 29, then comment line 32. This is because the book details page will otherwise use a passed in prop ID to fetch the specific book, obviously won't work if you're passing in nothing. After you do that, click on the about author, and you can comment the lines to how they were originally.

I fixed some scaling issues to that the book description doesn't get too long by using overflow: auto, but there's still a little gap the bottom of the card if the title takes up two lines, need to find a way to fix that.